### PR TITLE
feat(rendering): sync overlay frame rate to display refresh

### DIFF
--- a/include/webview.h
+++ b/include/webview.h
@@ -21,6 +21,7 @@ public slots:
   void onEditingEnded();
   void onLoaded(bool ok);
   void onKeyDown(QString key);
+  void syncAnimationFrameRate();
 
 private:
   QUrl baseUrl;

--- a/res/config/config.yml
+++ b/res/config/config.yml
@@ -1,14 +1,17 @@
-tosu:
-  url: http://127.0.0.1:24050
-  type: external
-  internal:
-    privileged: false
-    executable: /usr/bin/tosu
-    arguments: []
-    working-directory: /opt/tosu
-    auto-url: false
+# yaml-language-server: $schema=config-v1.schema.json
+version: 1
 
 overlay:
   monitor: 0
   attach: false
   start-hidden: false
+
+tosu:
+  url: http://127.0.0.1:24050
+  start-with-overlay:
+    enabled: true
+    privileged: false
+    executable: /usr/bin/tosu
+    arguments: []
+    working-directory: /opt/tosu
+    auto-url: false

--- a/res/scripts/tosu-overlay-injector.js
+++ b/res/scripts/tosu-overlay-injector.js
@@ -1,15 +1,82 @@
 (() => {
-  const script = document.createElement("script");
-  script.onload = function () {
-    let object;
-    new QWebChannel(
-      qt.webChannelTransport,
-      (channel) => (object = channel.objects.object),
-    );
-    document.addEventListener("keydown", (event) =>
-      object?.onKeyDown(event.key),
-    );
+  let maxFps = __TOSU_OVERLAY_MAX_FPS__;
+  let minFrameIntervalMs = maxFps > 0 ? 1000 / maxFps : 0;
+  const nativeRequestAnimationFrame = window.requestAnimationFrame.bind(window);
+  const pendingAnimationFrames = new Map();
+  let nextAnimationFrameId = 0;
+  let scheduledAnimationFrame = null;
+  let lastTimestamp = null;
+
+  const scheduleAnimationFramePump = () => {
+    if (scheduledAnimationFrame !== null) {
+      return;
+    }
+
+    scheduledAnimationFrame = nativeRequestAnimationFrame((timestamp) => {
+      scheduledAnimationFrame = null;
+      if (pendingAnimationFrames.size === 0) {
+        return;
+      }
+
+      if (minFrameIntervalMs > 0 && lastTimestamp !== null && timestamp - lastTimestamp < minFrameIntervalMs) {
+        scheduleAnimationFramePump();
+        return;
+      }
+
+      lastTimestamp = timestamp;
+      const callbacks = Array.from(pendingAnimationFrames.values());
+      pendingAnimationFrames.clear();
+
+      for (const callback of callbacks) {
+        callback(timestamp);
+      }
+
+      if (pendingAnimationFrames.size > 0) {
+        scheduleAnimationFramePump();
+      }
+    });
   };
-  script.src = "qrc:///qtwebchannel/qwebchannel.js";
-  document.body.appendChild(script);
+
+  window.__tosuOverlaySetAnimationFrameRate = (fps) => {
+    if (!Number.isFinite(fps) || fps <= 0) {
+      return;
+    }
+
+    maxFps = fps;
+    minFrameIntervalMs = 1000 / maxFps;
+    lastTimestamp = null;
+  };
+
+  window.requestAnimationFrame = (callback) => {
+    const animationFrameId = ++nextAnimationFrameId;
+    pendingAnimationFrames.set(animationFrameId, callback);
+    scheduleAnimationFramePump();
+    return animationFrameId;
+  };
+
+  window.cancelAnimationFrame = (animationFrameId) => {
+    pendingAnimationFrames.delete(animationFrameId);
+  };
+
+  const initializeChannel = () => {
+    const script = document.createElement("script");
+    script.onload = function () {
+      let object;
+      new QWebChannel(
+        qt.webChannelTransport,
+        (channel) => (object = channel.objects.object),
+      );
+      document.addEventListener("keydown", (event) =>
+        object?.onKeyDown(event.key),
+      );
+    };
+    script.src = "qrc:///qtwebchannel/qwebchannel.js";
+    (document.head || document.documentElement).appendChild(script);
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeChannel, { once: true });
+  } else {
+    initializeChannel();
+  }
 })();

--- a/schema/config-v1.schema.json
+++ b/schema/config-v1.schema.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+      "version": {
+        "type": "number",
+        "description": "The version of the configuration schema.",
+        "default": 1,
+        "minimum": 1,
+        "maximum": 1
+      },
+      "overlay": {
+        "type": "object",
+        "properties": {
+          "monitor": {
+            "oneOf": [
+              {
+                "type": "number",
+                "default": 0,
+                "minimum": 0,
+                "description": "Index number of monitor to put overlay on"
+              },
+              {
+                "type": "string",
+                "description": "Monitor to put overlay on"
+              }
+            ]
+          },
+          "attach": {
+            "type": "boolean"
+          },
+          "start-hidden": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "tosu": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Base URL of the tosu server",
+            "default": "http://127.0.0.1:24050"
+          },
+          "start-with-overlay": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether to start tosu with the overlay",
+                "default": false
+              },
+              "privileged": {
+                "type": "boolean",
+                "description": "Whether to start tosu with elevated privileges",
+                "default": true
+              },
+              "executable": {
+                "type": "string",
+                "description": "Path to the tosu executable",
+                "default": "/usr/bin/tosu"
+              },
+              "arguments": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Additional command line arguments to pass to tosu on start",
+                "default": []
+              },
+              "working-directory": {
+                "type": "string",
+                "description": "Working directory to start tosu in"
+              },
+              "auto-url": {
+                "type": "boolean",
+                "description": "Whether to automatically set the tosu URL on start",
+                "default": true
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "required": ["version"],
+    "additionalProperties": false
+  }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,9 +4,41 @@
 
 #include <LayerShellQt/Shell>
 #include <QApplication>
+#include <QByteArray>
+#include <QSurfaceFormat>
+
+namespace {
+constexpr auto kDisableFrameRateLimit = "--disable-frame-rate-limit";
+
+bool hasChromiumFlag(const QByteArray &flags, const QByteArray &flag) {
+  for (const auto &token : flags.split(' ')) {
+    if (token == flag) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void configureRenderingDefaults() {
+  auto surfaceFormat = QSurfaceFormat::defaultFormat();
+  surfaceFormat.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
+  surfaceFormat.setSwapInterval(1);
+  QSurfaceFormat::setDefaultFormat(surfaceFormat);
+
+  auto chromiumFlags = qgetenv("QTWEBENGINE_CHROMIUM_FLAGS");
+  if (!hasChromiumFlag(chromiumFlags, kDisableFrameRateLimit)) {
+    if (!chromiumFlags.isEmpty()) {
+      chromiumFlags.append(' ');
+    }
+    chromiumFlags.append(kDisableFrameRateLimit);
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", chromiumFlags);
+  }
+}
+} // namespace
 
 int main(int argc, char *argv[]) {
   LayerShellQt::Shell::useLayerShell();
+  configureRenderingDefaults();
   QApplication app(argc, argv);
   QApplication::setApplicationName(APPLICATION_NAME);
   QApplication::setApplicationDisplayName("Tosu Overlay");

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -39,8 +39,10 @@ Overlay::Overlay(QWidget *parent) : QWidget(parent) {
   createWinId();
 
   connect(windowHandle(), SIGNAL(visibleChanged(bool)), systemTray, SLOT(onVisibleChange(bool)));
+  connect(windowHandle(), SIGNAL(screenChanged(QScreen *)), webView, SLOT(syncAnimationFrameRate()));
   connect(this, SIGNAL(editingStarted()), systemTray, SLOT(onEditingStarted()));
   connect(this, SIGNAL(editingEnded()), systemTray, SLOT(onEditingEnded()));
+  webView->syncAnimationFrameRate();
 
   systemTray->show();
   emit editingEnded();

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -13,6 +13,9 @@
 #include <QTextStream>
 #include <QVBoxLayout>
 #include <QWebChannel>
+#include <QWebEngineScript>
+#include <QWebEngineScriptCollection>
+#include <QtGlobal>
 
 WebView::WebView(QWidget *parent, const QUrl baseUrl) : QWebEngineView{parent} {
   setPage(new WebPage(this));
@@ -23,27 +26,68 @@ WebView::WebView(QWidget *parent, const QUrl baseUrl) : QWebEngineView{parent} {
 
 WebView::~WebView() { delete this->page(); }
 
-static QString script;
-
-static inline void inject(QWebEnginePage *page) {
-  if (script.isEmpty()) {
+static QString loadInjectorTemplate() {
+  static QString injectorTemplate;
+  if (injectorTemplate.isEmpty()) {
     QFile file(":/scripts/tosu-overlay-injector.js");
     if (!file.open(QFile::ReadOnly)) {
       qWarning("Failed to open tosu-overlay-injector.js");
-      return;
+      return {};
     }
     QTextStream in(&file);
-    script = in.readAll();
+    injectorTemplate = in.readAll();
     file.close();
   }
-  page->runJavaScript(script);
+  return injectorTemplate;
+}
+
+static double detectRefreshRate(const QWidget *widget) {
+  constexpr double defaultRefreshRate = 60.0;
+  auto *screen = widget != nullptr ? widget->screen() : QApplication::primaryScreen();
+  if (screen == nullptr) {
+    return defaultRefreshRate;
+  }
+
+  const auto refreshRate = screen->refreshRate();
+  if (!qIsFinite(refreshRate) || refreshRate < 1.0) {
+    return defaultRefreshRate;
+  }
+
+  return qBound(30.0, refreshRate, 360.0);
+}
+
+static QString animationFrameRateScript(double refreshRate) {
+  return QStringLiteral(
+             "if (typeof window.__tosuOverlaySetAnimationFrameRate === 'function') { "
+             "window.__tosuOverlaySetAnimationFrameRate(%1); }")
+      .arg(QString::number(refreshRate, 'f', 3));
+}
+
+static void installPageScript(QWebEnginePage *page, const QWidget *widget) {
+  const auto injectorTemplate = loadInjectorTemplate();
+  if (injectorTemplate.isEmpty()) {
+    return;
+  }
+
+  auto injectorSource = injectorTemplate;
+  injectorSource.replace("__TOSU_OVERLAY_MAX_FPS__", QString::number(detectRefreshRate(widget), 'f', 3));
+
+  QWebEngineScript injector;
+  injector.setName("tosu-overlay-injector");
+  injector.setInjectionPoint(QWebEngineScript::DocumentCreation);
+  injector.setRunsOnSubFrames(false);
+  injector.setWorldId(QWebEngineScript::MainWorld);
+  injector.setSourceCode(injectorSource);
+  page->scripts().insert(injector);
 }
 
 void WebView::onLoaded(bool ok) {
   setVisible(ok);
   if (ok) {
-    inject(page());
-  } else {
+    syncAnimationFrameRate();
+    return;
+  }
+  if (!ok) {
     auto *msgBox = new QMessageBox(parentWidget());
     msgBox->setFixedSize(462, 125);
     msgBox->createWinId();
@@ -82,6 +126,10 @@ void WebView::setTosuBaseUrl(const QUrl baseUrl) {
   this->setUrl(overlayUrl);
 }
 
+void WebView::syncAnimationFrameRate() {
+  page()->runJavaScript(animationFrameRateScript(detectRefreshRate(this)));
+}
+
 void WebView::onKeyDown(QString key) {
   if (key == "Esc" || key == "Escape") {
     emit editingEnd();
@@ -94,6 +142,7 @@ void WebView::onEditingEnded() { this->page()->runJavaScript("window.postMessage
 
 WebPage::WebPage(WebView *parent) : QWebEnginePage{parent} {
   this->setBackgroundColor(Qt::transparent);
+  installPageScript(this, parent);
   QWebChannel *channel = new QWebChannel(parent);
   this->setWebChannel(channel);
   WebChannelObject *object = new WebChannelObject(parent);


### PR DESCRIPTION
## Summary
- move the overlay injector to a document-creation script installed on the page
- cap the overlay animation frame rate to the current screen refresh rate and resync on screen changes
- set rendering defaults and add Chromium's `--disable-frame-rate-limit` flag before `QApplication` startup

## Verification
- `meson setup build-review && meson compile -C build-review`
- headless Chromium check of native `requestAnimationFrame` cancellation and exception behavior

## Notes
- Opened as draft because the review found two follow-up risks in the new `requestAnimationFrame` shim: same-frame cancellation is not honored, and one callback exception can suppress later callbacks in the same frame.
